### PR TITLE
Add coveralls take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,7 @@ language: go
 go:
   - 1.14.x
 
-jobs:
-  include:
-    - stage: test
-      script:
-        - make test
-    - stage: test-and-coveralls
-      script:
-        - go get -u github.com/mattn/goveralls
-        - make test
-        - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci
-
-stages:
-  - name: test
-    if: NOT (branch = edge) OR (type IN (push, pull_request))
-  - name: test-and-coveralls
-    if: (branch = edge) AND (NOT (type IN (push, pull_request)))
+script:
+  - go get -u github.com/mattn/goveralls
+  - make test
+  - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
The previous Travis config did not trigger the coveralls test job after PR merge (the documentation is unclear about how to use `type` options, and it's not obvious if it's possible at all to identify build jobs on edge _after_ PR merge, as opposed to PR build jobs while the PR is open). Setting coveralls checkin for all builds for now.